### PR TITLE
🐛 处理并发请求防抖（a-b-a）

### DIFF
--- a/src/libs/axios-client.ts
+++ b/src/libs/axios-client.ts
@@ -82,14 +82,14 @@ export class AxiosClient {
   public request<R>(conf: AxiosRequestConfig): Promise<AxiosResponse<R>> {
     const options: AxiosClientConfig = Object.assign({}, this.defaultConfig, conf);
     if (this.isDoubleClick(options)) {
-      const err: AxiosError = Object.assign(new Error('您多次点击按钮，导致响应中断，请刷新页面后再次操作！'), {
+      const err: AxiosError = Object.assign(new Error('duplicate request with same data'), {
         config: options as AxiosRequestConfig,
         isAxiosError: false,
         code: 'check-duplicate',
         toJSON: () => {
           return {
             success: false,
-            message: '您多次点击按钮，导致响应中断，请刷新页面后再次操作！',
+            message: 'duplicate request with same data',
           };
         },
       });
@@ -105,17 +105,20 @@ export class AxiosClient {
       const oldRequestTime = this.requests.get(id);
       const nowRequestTime = new Date().getTime();
       if (oldRequestTime != null && oldRequestTime > nowRequestTime) {
-        const err: AxiosError = Object.assign(new Error('组件初始化或并发请求中出现重复请求'), {
-          config: options as AxiosRequestConfig,
-          isAxiosError: false,
-          code: 'check-duplicate',
-          toJSON: () => {
-            return {
-              success: false,
-              message: '组件初始化或并发请求中出现重复请求',
-            };
+        const err: AxiosError = Object.assign(
+          new Error('duplicate requests occur during component initialization or concurrent requests'),
+          {
+            config: options as AxiosRequestConfig,
+            isAxiosError: false,
+            code: 'check-duplicate',
+            toJSON: () => {
+              return {
+                success: false,
+                message: 'duplicate requests occur during component initialization or concurrent requests',
+              };
+            },
           },
-        });
+        );
         return Promise.reject(err);
       }
 

--- a/src/locale/json/en-US.json
+++ b/src/locale/json/en-US.json
@@ -78,5 +78,8 @@
     "LeastNChars": "at least {0} chars",
     "RequireEmail": "require an email",
     "RequirePassword": "require a password"
+  },
+  "Test": {
+    "Concurrency": "ConcurrencyRequest"
   }
 }

--- a/src/locale/json/zh-CN.json
+++ b/src/locale/json/zh-CN.json
@@ -77,5 +77,8 @@
     "LeastNChars": "至少 {0} 字符",
     "RequireEmail": "需要邮箱",
     "RequirePassword": "需要密码"
+  },
+  "Test": {
+    "Concurrency": "并发请求"
   }
 }

--- a/src/views/mock/MockDoubler.vue
+++ b/src/views/mock/MockDoubler.vue
@@ -13,16 +13,33 @@
       <el-tag v-waiting="1000" style="margin: 1em" @click="waiting">Waiting1000</el-tag>
       <el-checkbox v-waiting="1000">Waiting1000</el-checkbox>
     </div>
+    <div class="wg-box-block">
+      <el-button type="primary" @click="concurrencyRequest">ConcurrencyRequest</el-button>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { mockDoubler, mockStatus } from '@/apis/mock/mock-data';
 import { ElMessage } from 'element-plus';
+import { onMounted } from 'vue';
+import { initUser } from '@/apis/authn/setting';
+
+onMounted(() => {
+  initUser();
+  mockDoubler(500);
+  initUser();
+});
 
 function debounce(w: number) {
   mockStatus(200, w);
   mockStatus(200, w);
+}
+
+function concurrencyRequest() {
+  initUser();
+  mockDoubler(500);
+  initUser();
 }
 
 function waiting() {


### PR DESCRIPTION
组件初始化或者发起并发请求场景下，同时发起了a-b-a请求，导致两次a请求没有防抖住，防止开发过程中不恰当的请求形式出现未知的结果。
1、当并发请求情况下出现重复请求时，页面上不会出现信息提示，用户并不需要知晓，因为这并不属于用户的不当操作，属于程序开发过程中的问题，所以只会在日志中出现警告。
2、而用户重复点击按钮导致的防抖，会出现信息提示，提醒用户请勿重复点击按钮。