### PR TITLE
✨ 增加本地测试加盟商功能

### DIFF
--- a/src/apis/authn/login.ts
+++ b/src/apis/authn/login.ts
@@ -84,4 +84,5 @@ export function oauth(type: string, state: string[], host: string, doSuccess: (r
 export function logout(): void {
   client.postForm('/auth/logout.json').then(emptyFunction);
   useAuthnStore().doLogout();
+  sessionStorage.removeItem('franchisee');
 }

--- a/src/components/authn/UserLogin.vue
+++ b/src/components/authn/UserLogin.vue
@@ -21,6 +21,7 @@
         <el-option v-for="item in runModeOpts" :key="item" :value="item" />
       </el-select>
       <el-button type="success" @click="loginTest">ForTest</el-button>
+      <el-button type="primary" @click="franchiseeLogin">FranchiseeLogin</el-button>
     </el-form-item>
   </el-form>
 </template>
@@ -107,6 +108,12 @@ function onRunMode() {
   changeRunMode(runModeTest.value);
 }
 function loginTest() {
+  useAuthnStore().name = 'test-only';
+  useSettingStore().locale = localeDefault;
+  props?.doSuccess(emptySuccess);
+}
+function franchiseeLogin() {
+  sessionStorage.setItem('franchisee', 'true');
   useAuthnStore().name = 'test-only';
   useSettingStore().locale = localeDefault;
   props?.doSuccess(emptySuccess);

--- a/src/libs/franchisee.ts
+++ b/src/libs/franchisee.ts
@@ -1,0 +1,10 @@
+import { isProduction } from '@/configs/global';
+
+export function isFranchisee() {
+  if (isProduction) {
+    const host = window.location.hostname.toLowerCase();
+    return !host.endsWith('buybuylabel.com');
+  } else {
+    return JSON.parse(sessionStorage.getItem('franchisee') as string) as boolean;
+  }
+}

--- a/src/locale/json/en-US.json
+++ b/src/locale/json/en-US.json
@@ -12,7 +12,8 @@
     "Logout": "Logout",
     "PlaceHolder": "Please input",
     "Refresh": "Refresh",
-    "SystemName": "Wings Admin System"
+    "SystemName": "Wings Admin System",
+    "Franchisee": "This is what franchisees cannot see"
   },
   "Error": {
     "NotFound404": "Page Not Found, please login",

--- a/src/locale/json/zh-CN.json
+++ b/src/locale/json/zh-CN.json
@@ -12,7 +12,8 @@
     "Logout": "登出",
     "PlaceHolder": "请输入",
     "Refresh": "刷新",
-    "SystemName": "Wings Admin System"
+    "SystemName": "Wings Admin System",
+    "Franchisee": "加盟商无法看到的内容"
   },
   "Error": {
     "NotFound404": "页面不存在，请登录",

--- a/src/views/mock/MockOthers.vue
+++ b/src/views/mock/MockOthers.vue
@@ -20,7 +20,9 @@
         <el-button :type="badgeType" @click="onMenuBadge(0)">MenuBadgeInput</el-button>
       </div>
     </div>
-    <div class="wg-box-block"></div>
+    <div class="wg-box-block">
+      <p v-if="!isFranchisee()">{{ t('Common.Franchisee') }}</p>
+    </div>
   </div>
 </template>
 
@@ -31,9 +33,12 @@ import { MenuItem } from '@/components/layout/AsideMenu';
 import { Opportunity } from '@element-plus/icons-vue';
 import { ref } from 'vue';
 import { useCachingStore } from '@/store/caching';
+import { isFranchisee } from '@/libs/franchisee';
+import { useI18n } from '@/locale';
 
 const cachingStore = useCachingStore();
 const router = useRouter();
+const { t } = useI18n();
 
 function onAddTab() {
   router.push({ name: RouteName.MockDetail, params: { id: '' + new Date().getTime() } });


### PR DESCRIPTION
原本系统针对加盟商功能的测试只能通过发布到线上之后才能看到具体的效果，现在添加isFranchisee工具函数，在本地可以进行加盟商身份登陆进行测试，生产模式下不会出现加盟商登陆按钮，方便了开发人员和产品对加盟商功能的测试。